### PR TITLE
Http Live Streaming用のバッファ"AudioFileSourceHLSBuffer"を実装。

### DIFF
--- a/src/AudioFileSourceHLSBuffer.cpp
+++ b/src/AudioFileSourceHLSBuffer.cpp
@@ -110,14 +110,19 @@ bool AudioFileSourceHLSBuffer::isFullSourceQueue()
 void AudioFileSourceHLSBuffer::addSource(AudioFileSource *src)
 {
   sourceQueue.push(src);
+  log_e("A File Source is Added.");
   return;
 }
 
 bool AudioFileSourceHLSBuffer::changeSource()
 {
-  if(sourceQueue.length() == 0) return false;
+  if(sourceQueue.length() == 0){
+    log_e("Source Queue is Empty.");
+    return false;
+  }
   delete src;
   src = sourceQueue.pop();
+  log_e("Source Changed.");
   return true;
 }
 

--- a/src/AudioFileSourceHLSBuffer.cpp
+++ b/src/AudioFileSourceHLSBuffer.cpp
@@ -1,0 +1,219 @@
+/*
+  AudioFileSourceHLSBuffer
+  Double-buffered file source using system RAM for http live streaming
+  
+  Copyright (C) 2021  Osamu Miyazawa
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#include <Arduino.h>
+#include "AudioFileSourceHLSBuffer.h"
+
+#pragma GCC optimize ("O3")
+
+AudioFileSourceHLSBuffer::AudioFileSourceHLSBuffer(AudioFileSource *source, uint32_t buffSizeBytes, bool isTSData)
+{
+  buffSize = buffSizeBytes;
+  buffer = (uint8_t*)malloc(sizeof(uint8_t) * buffSize);
+  if (!buffer) audioLogger->printf_P(PSTR("Unable to allocate AudioFileSourceHLSBuffer::buffer[]\n"));
+  deallocateBuffer = true;
+  writePtr = 0;
+  readPtr = 0;
+  src = source;
+  length = 0;
+  filled = false;
+  isTSBuffer = isTSData;
+}
+
+AudioFileSourceHLSBuffer::AudioFileSourceHLSBuffer(AudioFileSource *source, void *inBuff, uint32_t buffSizeBytes, bool isTSData)
+{
+  buffSize = buffSizeBytes;
+  buffer = (uint8_t*)inBuff;
+  deallocateBuffer = false;
+  writePtr = 0;
+  readPtr = 0;
+  src = source;
+  length = 0;
+  filled = false;
+  isTSBuffer = isTSData;
+}
+
+AudioFileSourceHLSBuffer::~AudioFileSourceHLSBuffer()
+{
+  if (deallocateBuffer) free(buffer);
+  buffer = NULL;
+}
+
+bool AudioFileSourceHLSBuffer::seek(int32_t pos, int dir)
+{
+  if(dir == SEEK_CUR && (readPtr+pos) < length) {
+    readPtr += pos;
+    return true;
+  } else {
+    // Invalidate
+    readPtr = 0;
+    writePtr = 0;
+    length = 0;
+    return src->seek(pos, dir);
+  }
+}
+
+bool AudioFileSourceHLSBuffer::close()
+{
+  if (deallocateBuffer) free(buffer);
+  buffer = NULL;
+  return src->close();
+}
+
+bool AudioFileSourceHLSBuffer::isOpen()
+{
+  return src->isOpen();
+}
+
+uint32_t AudioFileSourceHLSBuffer::getSize()
+{
+  return src->getSize();
+}
+
+uint32_t AudioFileSourceHLSBuffer::getPos()
+{
+  return src->getPos();
+}
+
+uint32_t AudioFileSourceHLSBuffer::getFillLevel()
+{
+  return length;
+}
+
+bool AudioFileSourceHLSBuffer::isTS()
+{
+  return isTSBuffer;
+}
+
+bool AudioFileSourceHLSBuffer::isFullSourceQueue()
+{
+  return sourceQueue.length() >= QUEUESIZE;
+}
+
+void AudioFileSourceHLSBuffer::addSource(AudioFileSource *src)
+{
+  sourceQueue.push(src);
+  return;
+}
+
+bool AudioFileSourceHLSBuffer::changeSource()
+{
+  if(sourceQueue.length() == 0) return false;
+  delete src;
+  src = sourceQueue.pop();
+  return true;
+}
+
+uint32_t AudioFileSourceHLSBuffer::read(void *data, uint32_t len)
+{
+  if (!buffer) return src->read(data, len);
+
+  uint32_t bytes = 0;
+  if (!filled) {
+    // Fill up completely before returning any data at all
+    cb.st(STATUS_FILLING, PSTR("Refilling buffer"));
+    length = src->read(buffer, buffSize);
+    writePtr = length % buffSize;
+    filled = true;
+  }
+
+  // Pull from buffer until we've got none left or we've satisfied the request
+  uint8_t *ptr = reinterpret_cast<uint8_t*>(data);
+  uint32_t toReadFromBuffer = (len < length) ? len : length;
+  if ( (toReadFromBuffer > 0) && (readPtr >= writePtr) ) {
+    uint32_t toReadToEnd = (toReadFromBuffer < (uint32_t)(buffSize - readPtr)) ? toReadFromBuffer : (buffSize - readPtr);
+    memcpy(ptr, &buffer[readPtr], toReadToEnd);
+    readPtr = (readPtr + toReadToEnd) % buffSize;
+    len -= toReadToEnd;
+    length -= toReadToEnd;
+    ptr += toReadToEnd;
+    bytes += toReadToEnd;
+    toReadFromBuffer -= toReadToEnd;
+  }
+  if (toReadFromBuffer > 0) { // We know RP < WP at this point
+    memcpy(ptr, &buffer[readPtr], toReadFromBuffer);
+    readPtr = (readPtr + toReadFromBuffer) % buffSize;
+    len -= toReadFromBuffer;
+    length -= toReadFromBuffer;
+    ptr += toReadFromBuffer;
+    bytes += toReadFromBuffer;
+    toReadFromBuffer -= toReadFromBuffer;
+  }
+
+  if (len) {
+    // Still need more, try direct read from src
+    bytes += src->read(ptr, len);
+    // We're out of buffered data, need to force a complete refill.  Thanks, @armSeb
+    readPtr = 0;
+    writePtr = 0;
+    length = 0;
+    filled = false;
+    cb.st(STATUS_UNDERFLOW, PSTR("Buffer underflow"));
+  }
+
+  fill();
+
+  return bytes;
+}
+
+void AudioFileSourceHLSBuffer::fill()
+{
+  if (!buffer) return;
+
+  if (length < buffSize) {
+    // Now try and opportunistically fill the buffer
+    if (readPtr > writePtr) {
+      if (readPtr == writePtr+1) return;
+      uint32_t bytesAvailMid = readPtr - writePtr - 1;
+      int cnt = src->readNonBlock(&buffer[writePtr], bytesAvailMid);
+      if(cnt == 0 && changeSource()) cnt = src->readNonBlock(&buffer[writePtr], bytesAvailMid);
+      length += cnt;
+      writePtr = (writePtr + cnt) % buffSize;
+      return;
+    }
+
+    if (buffSize > writePtr) {
+      uint32_t bytesAvailEnd = buffSize - writePtr;
+      int cnt = src->readNonBlock(&buffer[writePtr], bytesAvailEnd);
+      if(cnt == 0 && changeSource()) cnt = src->readNonBlock(&buffer[writePtr], bytesAvailEnd);
+      length += cnt;
+      writePtr = (writePtr + cnt) % buffSize;
+      if (cnt != (int)bytesAvailEnd) return;
+    }
+
+    if (readPtr > 1) {
+      uint32_t bytesAvailStart = readPtr - 1;
+      int cnt = src->readNonBlock(&buffer[writePtr], bytesAvailStart);
+      if(cnt == 0 && changeSource()) cnt = src->readNonBlock(&buffer[writePtr], bytesAvailStart);
+      length += cnt;
+      writePtr = (writePtr + cnt) % buffSize;
+    }
+  }
+}
+
+
+
+bool AudioFileSourceHLSBuffer::loop()
+{
+  if (!src->loop()) return false;
+  fill();
+  return true;
+}  
+

--- a/src/AudioFileSourceHLSBuffer.h
+++ b/src/AudioFileSourceHLSBuffer.h
@@ -1,0 +1,70 @@
+/*
+  AudioFileSourceHLSBuffer
+  Double-buffered input file using system RAM for http live streaming
+
+  Copyright (C) 2021  Osamu Miyazawa
+
+  This program is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  This program is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY; without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+#ifndef _AUDIOFILESOURCEBUFFER_H
+#define _AUDIOFILESOURCEBUFFER_H
+
+#include <AudioFileSource.h>
+#include "Queue.h"
+
+
+class AudioFileSourceHLSBuffer : public AudioFileSource
+{
+  public:
+    AudioFileSourceHLSBuffer(AudioFileSource *in, uint32_t bufferBytes, bool isTSData);
+    AudioFileSourceHLSBuffer(AudioFileSource *in, void *buffer, uint32_t bufferBytes, bool isTSData); // Pre-allocated buffer by app
+    virtual ~AudioFileSourceHLSBuffer() override;
+    
+    virtual uint32_t read(void *data, uint32_t len) override;
+    virtual bool seek(int32_t pos, int dir) override;
+    virtual bool close() override;
+    virtual bool isOpen() override;
+    virtual uint32_t getSize() override;
+    virtual uint32_t getPos() override;
+    virtual bool loop() override;
+
+    virtual uint32_t getFillLevel();
+
+    enum { STATUS_FILLING=2, STATUS_UNDERFLOW };
+
+    void addSource(AudioFileSource *src);
+    bool isTS();
+    bool isFullSourceQueue();
+
+  private:
+    virtual void fill();
+    bool changeSource();
+
+  private:
+    AudioFileSource *src;
+    Queue<AudioFileSource*> sourceQueue;
+    uint32_t buffSize;
+    uint8_t *buffer;
+    bool deallocateBuffer;
+    uint32_t writePtr;
+    uint32_t readPtr;
+    uint32_t length;
+    bool filled;
+    bool isTSBuffer;
+};
+
+
+#endif
+

--- a/src/AudioFileSourceHLSBuffer.h
+++ b/src/AudioFileSourceHLSBuffer.h
@@ -24,6 +24,8 @@
 #include <AudioFileSource.h>
 #include "Queue.h"
 
+#define SOURCE_QUEUE_CAPACITY 2
+#define FILE_SIZE_LIMIT 1000000  // If a source size exceed it, some problem may have occurred.
 
 class AudioFileSourceHLSBuffer : public AudioFileSource
 {
@@ -47,7 +49,6 @@ class AudioFileSourceHLSBuffer : public AudioFileSource
     void addSource(AudioFileSource *src);
     bool isTS();
     bool isFullSourceQueue();
-    uint8_t getLengthSourceQueue();
 
   private:
     virtual void fill();

--- a/src/AudioFileSourceHLSBuffer.h
+++ b/src/AudioFileSourceHLSBuffer.h
@@ -47,6 +47,7 @@ class AudioFileSourceHLSBuffer : public AudioFileSource
     void addSource(AudioFileSource *src);
     bool isTS();
     bool isFullSourceQueue();
+    uint8_t getLengthSourceQueue();
 
   private:
     virtual void fill();
@@ -54,7 +55,7 @@ class AudioFileSourceHLSBuffer : public AudioFileSource
 
   private:
     AudioFileSource *src;
-    Queue<AudioFileSource*> sourceQueue;
+    Queue<AudioFileSource*> *sourceQueue;
     uint32_t buffSize;
     uint8_t *buffer;
     bool deallocateBuffer;

--- a/src/AudioGeneratorTS.cpp
+++ b/src/AudioGeneratorTS.cpp
@@ -320,6 +320,7 @@ uint32_t AudioGeneratorTS::readFile(void *data, uint32_t len)
 
 bool AudioGeneratorTS::FillBufferWithValidFrame()
 {
+  //log_e("FillBuffer is called.");
   buff[0] = 0; // Destroy any existing sync word @ 0
   int nextSync;
   do {
@@ -341,22 +342,22 @@ bool AudioGeneratorTS::FillBufferWithValidFrame()
       }
     }
   } while (nextSync == -1);
-
+  //log_e("nextSync:%d", nextSync);
   // Move the frame to start at offset 0 in the buffer
   buffValid -= nextSync; // Throw out prior to nextSync
   memmove(buff, buff+nextSync, buffValid);
-
+  log_i("buffValid:%d", buffValid);
   // We have a sync word at 0 now, try and fill remainder of buffer
   //buffValid += file->read(buff + buffValid, buffLen - buffValid);
   buffValid += isInputTs ? readFile(buff + buffValid, buffLen - buffValid) : file->read(buff + buffValid, buffLen - buffValid);
-  log_v("buffValid: %d", buffValid);
+  log_i("buffValid: %d", buffValid);
 
   return true;
 }
 
 bool AudioGeneratorTS::loop()
 {
-  log_d("AudioGeneratorTS::loop() is called.");
+  //log_e("AudioGeneratorTS::loop() is called.");
   if (!running) goto done; // Nothing to do here!
 
   // If we've got data, try and pump it out...

--- a/src/HLSUrl.cpp
+++ b/src/HLSUrl.cpp
@@ -4,7 +4,6 @@ HLSUrl::HLSUrl(String url)
 {
   targetDuration = 10;
   searchPlaylistUrl(url);
-  log_e("HLSUrl Created.");
 }
 
 HLSUrl::~HLSUrl()

--- a/src/HLSUrl.cpp
+++ b/src/HLSUrl.cpp
@@ -1,0 +1,51 @@
+#include "HLSUrl.h"
+
+HLSUrl::HLSUrl(String url)
+{
+  targetDuration = 10;
+  searchPlaylistUrl(url);
+}
+
+HLSUrl::~HLSUrl()
+{
+}
+
+void HLSUrl::searchPlaylistUrl(const String url)
+{
+  String res;
+  uint8_t status;
+  m3u8Urls.push(url);
+  do
+  {
+    res = getRequest(m3u8Urls.peek());
+    status = parseResponse(res, targetDuration, m3u8Urls, segmentUrls);
+    log_v("status: %d", status);
+    delay(100);
+  } while (status != 1);
+  playlistUrl = m3u8Urls.peek();
+  return;
+}
+
+bool HLSUrl::crawlSegmentUrl()
+{
+  if(!m3u8Urls.depth()) return false;
+  String res = getRequest(playlistUrl);
+  uint8_t status = parseResponse(res, targetDuration, m3u8Urls, segmentUrls);
+  if(status == 0) return false;
+  return true;
+}
+
+uint8_t HLSUrl::getTargetDuration()
+{
+  return targetDuration;
+}
+
+int HLSUrl::length()
+{
+  return segmentUrls.length();
+}
+
+String HLSUrl::pop()
+{
+  return segmentUrls.pop();
+}

--- a/src/HLSUrl.cpp
+++ b/src/HLSUrl.cpp
@@ -4,6 +4,7 @@ HLSUrl::HLSUrl(String url)
 {
   targetDuration = 10;
   searchPlaylistUrl(url);
+  log_e("HLSUrl Created.");
 }
 
 HLSUrl::~HLSUrl()

--- a/src/HLSUrl.h
+++ b/src/HLSUrl.h
@@ -1,0 +1,18 @@
+#include <Arduino.h>
+#include "HttpCommunicator.h"
+
+class HLSUrl {
+public:
+  HLSUrl(String url);
+  ~HLSUrl();
+  int length();
+  String pop();
+  bool crawlSegmentUrl();
+  uint8_t getTargetDuration();
+private:
+  String playlistUrl;
+  uint8_t targetDuration;
+  Queue<String> segmentUrls;
+  Stack<String> m3u8Urls;
+  void searchPlaylistUrl(String url);
+};

--- a/src/M3U8Player.cpp
+++ b/src/M3U8Player.cpp
@@ -49,7 +49,7 @@ M3U8Player::M3U8Player(String url, const float &startVolume)
 
   delay(1000);
   xTaskCreatePinnedToCore(this->scrapeAAC, "scrapeAAC", 2048 * 3, this, 0, &scrapeAACHandle, 0);
-  xTaskCreatePinnedToCore(this->playAAC,   "playAAC",   2048 * 16, this, 2, &playAACHandle,   1);
+  xTaskCreatePinnedToCore(this->playAAC,   "playAAC",   2048 * 4, this, 2, &playAACHandle,   1);
 
   targetDuration = urls->getTargetDuration();
 }
@@ -72,20 +72,20 @@ void M3U8Player::scrapeAAC(void* m3u8PlayerInstance)
   while (true)
   {
     if (!instance->isPlaying) {
-      log_e("Not Playing Now...");
+      log_i("Not Playing Now...");
       delay(100);
       continue;
     }
     if (instance->buff && (millis() - lastRequested >= instance->targetDuration * KILO))
     {
-      log_i("playAAC Stack: %d", uxTaskGetStackHighWaterMark(instance->playAACHandle));
+      log_e("playAAC Stack: %d", uxTaskGetStackHighWaterMark(instance->playAACHandle));
       instance->urls->crawlSegmentUrl();
       lastRequested = millis();
 
-      while (instance->urls->length() && !instance->buff->isFullSourceQueue() && (instance->buff->getLengthSourceQueue() < 3))
+      while (instance->urls->length() && !instance->buff->isFullSourceQueue())
       {
         String convertedUrl = convertHTTPStoHTTP(instance->urls->pop());
-        log_i("%s", convertedUrl.c_str());
+        log_e("%s", convertedUrl.c_str());
         AudioFileSourceHTTPStream *file = new AudioFileSourceHTTPStream(convertedUrl.c_str());
         instance->buff->addSource(file);
       }

--- a/src/M3U8Player.cpp
+++ b/src/M3U8Player.cpp
@@ -61,10 +61,15 @@ M3U8Player::~M3U8Player(){
 void M3U8Player::scrapeAAC(void* m3u8PlayerInstance)
 {
   M3U8Player* instance = (M3U8Player*) m3u8PlayerInstance;
-  uint32_t lastRequested = millis();
+  uint32_t lastRequested = 0;
 
   while (true)
   {
+    if (!instance->isPlaying) {
+      log_e("Not Playing Now...");
+      delay(100);
+      continue;
+    }
     if (millis() - lastRequested >= instance->targetDuration * KILO)
     {
       log_i("playAAC Stack: %d", uxTaskGetStackHighWaterMark(instance->playAACHandle));

--- a/src/M3U8Player.cpp
+++ b/src/M3U8Player.cpp
@@ -7,12 +7,10 @@ M3U8Player::M3U8Player(String url)
   playAACHandle = NULL;
   volume = 5.0;
   buffSize = 4096;
-  targetDuration = 10;
   isChannelChanged = false;
-  needNextBuff = false;
   isPlaying = false;
   stationUrl = url;
-  m3u8Urls.push(stationUrl);
+  urls = new HLSUrl(stationUrl);
 
   out = new AudioOutputI2S(0, 1);
   out->SetOutputModeMono(true);
@@ -20,10 +18,10 @@ M3U8Player::M3U8Player(String url)
   ts = new AudioGeneratorTS();
 
   delay(1000);
-  scrapeM3U8();
   xTaskCreatePinnedToCore(this->scrapeAAC, "scrapeAAC", 2048 * 3, this, 0, &scrapeAACHandle, 0);
-  xTaskCreatePinnedToCore(this->setBuffer, "setBuffer", 2048 * 1, this, 1, &setBufferHandle, 0);
   xTaskCreatePinnedToCore(this->playAAC,   "playAAC",   2048 * 4, this, 2, &playAACHandle,   1);
+
+  targetDuration = urls->getTargetDuration();
 }
 
 M3U8Player::M3U8Player(String url, const float &startVolume)
@@ -33,12 +31,10 @@ M3U8Player::M3U8Player(String url, const float &startVolume)
   playAACHandle = NULL;
   volume = startVolume;
   buffSize = 4096;
-  targetDuration = 10;
   isChannelChanged = false;
-  needNextBuff = false;
   isPlaying = false;
   stationUrl = url;
-  m3u8Urls.push(stationUrl);
+  urls = new HLSUrl(stationUrl);
 
   out = new AudioOutputI2S(0, 1);
   out->SetOutputModeMono(true);
@@ -46,10 +42,10 @@ M3U8Player::M3U8Player(String url, const float &startVolume)
   ts = new AudioGeneratorTS();
 
   delay(1000);
-  scrapeM3U8();
   xTaskCreatePinnedToCore(this->scrapeAAC, "scrapeAAC", 2048 * 3, this, 0, &scrapeAACHandle, 0);
-  xTaskCreatePinnedToCore(this->setBuffer, "setBuffer", 2048 * 1, this, 1, &setBufferHandle, 0);
   xTaskCreatePinnedToCore(this->playAAC,   "playAAC",   2048 * 4, this, 2, &playAACHandle,   1);
+
+  targetDuration = urls->getTargetDuration();
 }
 
 M3U8Player::~M3U8Player(){
@@ -58,122 +54,91 @@ M3U8Player::~M3U8Player(){
   vTaskDelete(playAACHandle);
   delete out;
   delete ts;
+  delete urls;
   log_d("M3U8Player destructed.");
-}
-
-void M3U8Player::scrapeM3U8()
-{
-  String res;
-  uint8_t status;
-  do
-  {
-    while(!m3u8Urls.depth()){ delay(100); }
-    res = getRequest(m3u8Urls.peek());
-    status = parseResponse(res, targetDuration, m3u8Urls, aacUrls);
-    log_v("status: %d", status);
-    delay(100);
-  } while (status != 1);
-  isChannelChanged = false;
-  return;
 }
 
 void M3U8Player::scrapeAAC(void* m3u8PlayerInstance)
 {
   M3U8Player* instance = (M3U8Player*) m3u8PlayerInstance;
-  String res;
-  uint8_t status;
   uint32_t lastRequested = millis();
 
   while (true)
   {
-    if (instance->isChannelChanged)
-      instance->scrapeM3U8();
     if (millis() - lastRequested >= instance->targetDuration * KILO)
     {
       log_i("playAAC Stack: %d", uxTaskGetStackHighWaterMark(instance->playAACHandle));
-      while(!instance->m3u8Urls.depth()){ delay(100); }
-      res = getRequest(instance->m3u8Urls.peek());
-      status = parseResponse(res, instance->targetDuration, instance->m3u8Urls, instance->aacUrls);
-      if (status == 0)
-      {
-        log_i("URL of .aac not found, retry...");
-        delay(3 * KILO);
-        continue;
-      }
+      instance->urls->crawlSegmentUrl();
       lastRequested = millis();
+
+      while (instance->urls->length() && !instance->buff->isFullSourceQueue())
+      {
+        instance->buff->addSource(new AudioFileSourceHTTPStream(instance->urls->pop().c_str()));
+      }
     }
     delay(100);
   }
 }
 
-void M3U8Player::setBuffer(void *m3u8PlayerInstance)
+void M3U8Player::setBuffer(HLSUrl* urlForBuff)
 {
-  M3U8Player *instance = (M3U8Player *)m3u8PlayerInstance;
-  AudioFileSourceHTTPStream *file;
-  String convertedUrl;
-  while (true)
-  {
-    if (instance->needNextBuff)
-    {
-      convertedUrl = convertHTTPStoHTTP(instance->aacUrls.pop());
-      log_i("%s", convertedUrl.c_str());
-      file = new AudioFileSourceHTTPStream(convertedUrl.c_str());
-      instance->nextBuff.isTS = (convertedUrl.indexOf(".ts") >= 0) ? true : false;
-      instance->nextBuff.buffer = new AudioFileSourceBuffer(file, instance->buffSize);
-      instance->needNextBuff = false;
-      instance->fileQueue.push(file);
-    }
-    delay(100);
-  }
+  String convertedUrl = convertHTTPStoHTTP(urlForBuff->pop());
+  log_i("%s", convertedUrl.c_str());
+  AudioFileSourceHTTPStream *file = new AudioFileSourceHTTPStream(convertedUrl.c_str());
+  bool isTS = (convertedUrl.indexOf(".ts") >= 0) ? true : false;
+  nextBuff = new AudioFileSourceHLSBuffer(file, buffSize, isTS);
 }
 
 void M3U8Player::playAAC(void *m3u8PlayerInstance)
 {
   M3U8Player *instance = (M3U8Player *)m3u8PlayerInstance;
   restart:
+  while (!instance->isPlaying){ delay(1000); }
   Serial.println("restarted or started.");
-  bool isNextBuffPrepared = false;
-  instance->needNextBuff = true;
-  while (!instance->isPlaying || instance->aacUrls.length() == 0){ delay(1000); }
-  while (!instance->nextBuff.buffer){ delay(100); }
+  instance->setBuffer(instance->urls);
+  while (!instance->nextBuff){ delay(100); }
   instance->buff = instance->nextBuff;
   instance->ts->reset();
-  instance->ts->switchMode(instance->buff.isTS);
+  instance->ts->switchMode(instance->buff->isTS());
+  instance->nextBuff = NULL;
 
   while (true)
   {
-    if (!instance->ts->begin(instance->buff.buffer, instance->out))
+    if (!instance->ts->begin(instance->buff, instance->out))
     {
       Serial.println("Player start failed.");
-      if (instance->buff.buffer){
-        instance->buff.buffer->close();
-        delete instance->buff.buffer;
+      if (instance->buff){
+        instance->buff->close();
+        delete instance->buff;
       }
-      if(instance->fileQueue.length() > 1) delete instance->fileQueue.pop();
+      if(instance->urls) delete instance->urls;
       goto restart;
     }
     while (instance->ts->isRunning())
     {
-      if (!isNextBuffPrepared && instance->buff.buffer->getSize() < 3 * instance->buff.buffer->getPos())
-      {
-        isNextBuffPrepared = true;
-        log_i("urls: %d", instance->aacUrls.length());
-        if (instance->aacUrls.length() == 0){ continue; }
-        log_i("prepare next buffer");
-        instance->needNextBuff = true;
-      }
       if (!instance->ts->loop())
       {
         instance->ts->stop();
-        instance->buff.buffer->close();
-        delete instance->fileQueue.pop();
-        delete instance->buff.buffer;
+        instance->buff->close();
+        delete instance->buff;
+        delete instance->urls;
+        Serial.println("End of Play");
+        instance->isPlaying = false;
+        goto restart;
+      }
+      if (instance->isChannelChanged && instance->nextBuff)
+      {
+        Serial.println("Change Channel");
+        instance->ts->stop();
+        instance->buff->close();
+        delete instance->buff;
+        delete instance->urls;
         instance->buff = instance->nextBuff;
-        instance->nextBuff.buffer = NULL;
-        isNextBuffPrepared = false;
-        instance->ts->reset();
-        instance->ts->switchMode(instance->buff.isTS);
-        log_i("scrapeAAC Stack: %d", uxTaskGetStackHighWaterMark(instance->scrapeAACHandle));
+        instance->urls = instance->nextUrls;
+        instance->nextBuff = NULL;
+        instance->nextUrls = NULL;
+        instance->isChannelChanged = false;
+        break;
       }
       delay(1);
     }
@@ -211,11 +176,9 @@ bool M3U8Player::changeStationURL(const String &url)
     log_i("invalid url");
     return false;
   }
-  m3u8Urls.clear();
-  m3u8Urls.push(url);
+  nextUrls = new HLSUrl(url);
+  setBuffer(nextUrls);
   isChannelChanged = true;
-  uint8_t leftNum = 1;
-  if(aacUrls.length() >= leftNum){ aacUrls.tearOff(leftNum); }
   return true;
 }
 

--- a/src/M3U8Player.h
+++ b/src/M3U8Player.h
@@ -1,15 +1,11 @@
 #include <Arduino.h>
 #include <HTTPClient.h>
 #include <AudioFileSourceHTTPStream.h>
-#include <AudioFileSourceBuffer.h>
 #include <AudioOutputI2S.h>
-#include "HttpCommunicator.h"
+#include "HLSUrl.h"
+#include "AudioFileSourceHLSBuffer.h"
 #include "AudioGeneratorTS.h"
 
-typedef struct {
-  bool isTS;
-  AudioFileSourceBuffer *buffer;
-} sourceBuffer;
 
 class M3U8Player {
 public:
@@ -28,19 +24,16 @@ private:
   TaskHandle_t setBufferHandle;
   TaskHandle_t playAACHandle;
   AudioGeneratorTS *ts;
-  sourceBuffer buff;
-  sourceBuffer nextBuff;
+  AudioFileSourceHLSBuffer* buff;
+  AudioFileSourceHLSBuffer* nextBuff;
   AudioOutputI2S *out;
   uint32_t buffSize;
   uint8_t targetDuration;
-  Queue<String> aacUrls;
-  Stack<String> m3u8Urls;
-  Queue<AudioFileSourceHTTPStream*> fileQueue;
+  HLSUrl* urls;  
+  HLSUrl* nextUrls;  
   bool isChannelChanged;
-  bool needNextBuff;
   bool isPlaying;
-  void scrapeM3U8();
+  void setBuffer(HLSUrl* url);
   static void scrapeAAC(void *args);
-  static void setBuffer(void *args);
   static void playAAC(void *args);
 };

--- a/src/Queue.h
+++ b/src/Queue.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <Arduino.h>
 #define QUEUESIZE 16
 

--- a/src/Queue.h
+++ b/src/Queue.h
@@ -1,13 +1,24 @@
 #pragma once
 #include <Arduino.h>
-#define QUEUESIZE 16
+#define DEFAULT_QUEUE_CAPACITY 15
 
 template <class T>
 class Queue {
-    static const int size = QUEUESIZE;
-    static const int capacity = size - 1;
 public:
     Queue(){
+        capacity = DEFAULT_QUEUE_CAPACITY;
+        size = capacity + 1;
+        head = 0;
+        tail = capacity;
+        data = new T[size];
+    }
+    Queue(int capa){
+        if(capa < 2) {
+            Serial.println("The specified size is too small.");
+            exit(1);
+        }
+        capacity = capa;
+        size = capacity + 1;
         head = 0;
         tail = capacity;
         data = new T[size];
@@ -60,6 +71,8 @@ public:
         tail = (head + leftNumber - 1) % size;
     }
 private:
+    int size;
+    int capacity;
     int head;
     int tail;
     T *data;

--- a/src/Stack.h
+++ b/src/Stack.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <Arduino.h>
 #define STACKSIZE 8
 


### PR DESCRIPTION
今まではHLSの各セグメントで別のAudioFileSourceBufferを使用し、切り替えの際に雑音が発生していた。
AudioFileSourceHLSBufferでは一つのチャンネルにつき一つのバッファを使い続けるので、切り替え時の雑音が生じない。