### PR TITLE
GZIP形式のプレイリストを解凍する機能を実装。

### DIFF
--- a/README-jp.md
+++ b/README-jp.md
@@ -17,9 +17,10 @@ M5StackおよびM5StickCでM3U8形式のWebラジオを再生するプログラ�
 
 ### 全M5コントローラ共通  
 [ESP8266Audio](https://github.com/earlephilhower/ESP8266Audio)  
+[uzlib](https://github.com/pfalcon/uzlib)  
 また、下記の通りコードを追加する必要あり。  
 
-#### AudioFileSourceHTTPStream.cpp  
+#### ESP8266Audio/src/AudioFileSourceHTTPStream.cpp  
 ```C++
 bool AudioFileSourceHTTPStream::close()
 {

--- a/README.md
+++ b/README.md
@@ -17,9 +17,10 @@ Support for .aac and .ts
 
 ### All M5 Controllers Common  
 [ESP8266Audio](https://github.com/earlephilhower/ESP8266Audio)  
+[uzlib](https://github.com/pfalcon/uzlib)  
 In addition, you need to add a code like the following.  
 
-#### AudioFileSourceHTTPStream.cpp  
+#### ESP8266Audio/src/AudioFileSourceHTTPStream.cpp  
 ```C++
 bool AudioFileSourceHTTPStream::close()
 {

--- a/library.json
+++ b/library.json
@@ -17,7 +17,11 @@
   "dependencies": [
     {
       "name": "ESP8266Audio",
-      "version": "~1.9.3"
+      "owner": "earlephilhower",
+      "version": "~1.9.7"
+    },
+    {
+      "name": "uzlib"
     }
   ],
   "examples": [

--- a/library.properties
+++ b/library.properties
@@ -8,4 +8,4 @@ category=Communication
 url=https://github.com/Yokohama-Miyazawa/M5HLSPlayer
 architectures=esp32
 includes=M3U8Player.h
-depends=ESP8266Audio
+depends=ESP8266Audio, uzlib

--- a/src/HttpCommunicator.cpp
+++ b/src/HttpCommunicator.cpp
@@ -16,6 +16,83 @@ bool isCode3XX(const int &code){
           code == HTTP_CODE_TEMPORARY_REDIRECT || code == HTTP_CODE_PERMANENT_REDIRECT);
 }
 
+String decompressGZIPStream(WiFiClient *gzipStream){
+  unsigned int dlen;
+  unsigned char *source, *dest;
+  int res;
+
+  uzlib_init();
+
+  const unsigned int len = gzipStream->available();
+  log_i("len: %d", len);
+  source = (unsigned char *)malloc(len);
+  const unsigned int c = gzipStream->readBytes(source, len);
+  if (c != len)
+  {
+    log_e("Error reading bytes. stream length: %d, actualy read: %d", len, c);
+    exit(1);
+  }
+
+  log_i("source[len - 4]: %d, source[len - 3]: %d, source[len - 2]: %d,  source[len - 1]: %d",
+        source[len - 4], source[len - 3], source[len - 2], source[len - 1]);
+  // 解凍後の長さを計算
+  dlen = source[len - 1];
+  dlen = 256 * dlen + source[len - 2];
+  dlen = 256 * dlen + source[len - 3];
+  dlen = 256 * dlen + source[len - 4];
+
+  const unsigned int outlen = dlen;
+  log_i("outlen: %d", outlen);
+
+  // 計算したdlenと実際の長さが異なる場合があるので、余分に長さを確保する
+  dlen++;
+  dest = (unsigned char *)malloc(dlen);
+
+  struct uzlib_uncomp d;
+  uzlib_uncompress_init(&d, NULL, 0);
+
+  d.source = source;
+  d.source_limit = source + len - 4;
+  d.source_read_cb = NULL;
+
+  res = uzlib_gzip_parse_header(&d);
+  if (res != TINF_OK)
+  {
+    log_e("Error parsing header: %d", res);
+    exit(1);
+  }
+
+  d.dest_start = d.dest = dest;
+
+  while (dlen)
+  {
+    unsigned int chunk_len = dlen < OUT_CHUNK_SIZE ? dlen : OUT_CHUNK_SIZE;
+    d.dest_limit = d.dest + chunk_len;
+    res = uzlib_uncompress_chksum(&d);
+    dlen -= chunk_len;
+    log_v("res: %d, dlen: %d", res, dlen);
+    if (res != TINF_OK)
+    {
+      break;
+    }
+  }
+
+  if (res != TINF_DONE)
+  {
+    log_e("Error during decompression: %d", res);
+    exit(-res);
+  }
+
+  log_i("decompressed %lu bytes", d.dest - dest);
+  log_d("RESULT\n%s", dest);
+  String unzipped = String((char *)dest).substring(0, outlen);
+  free(source);
+  free(dest);
+  log_d("decompressed text: %s\ndecompressed text end", unzipped.c_str());
+
+  return unzipped;
+}
+
 response getRequest(const String &url)
 {
   HTTPClient http;
@@ -38,85 +115,10 @@ response getRequest(const String &url)
       if (!http.header("Content-Encoding").compareTo("gzip"))
       {
         log_i("GZIP");
-
-        unsigned int dlen;
-        unsigned char *source, *dest;
-        int res;
-
-        uzlib_init();
-
-        WiFiClient *stream = http.getStreamPtr();
-        const unsigned int len = stream->available();
-        log_i("len: %d", len);
-        source = (unsigned char *)malloc(len);
-        const unsigned int c = stream->readBytes(source, len);
-        if (c != len)
-        {
-          log_e("Error reading bytes. stream length: %d, actualy read: %d", len, c);
-          exit(1);
-        }
-
-        log_i("source[len - 4]: %d, source[len - 3]: %d, source[len - 2]: %d,  source[len - 1]: %d",
-               source[len - 4], source[len - 3], source[len - 2], source[len - 1]);
-        // 解凍後の長さを計算
-        dlen = source[len - 1];
-        dlen = 256 * dlen + source[len - 2];
-        dlen = 256 * dlen + source[len - 3];
-        dlen = 256 * dlen + source[len - 4];
-
-        const unsigned int outlen = dlen;
-        log_i("outlen: %d", outlen);
-
-        // 計算したdlenと実際の長さが異なる場合があるので、余分に長さを確保する
-        dlen++;
-        dest = (unsigned char *)malloc(dlen);
-
-        struct uzlib_uncomp d;
-        uzlib_uncompress_init(&d, NULL, 0);
-
-        d.source = source;
-        d.source_limit = source + len - 4;
-        d.source_read_cb = NULL;
-
-        res = uzlib_gzip_parse_header(&d);
-        if (res != TINF_OK)
-        {
-          log_e("Error parsing header: %d", res);
-          exit(1);
-        }
-
-        d.dest_start = d.dest = dest;
-
-        while (dlen)
-        {
-          unsigned int chunk_len = dlen < OUT_CHUNK_SIZE ? dlen : OUT_CHUNK_SIZE;
-          d.dest_limit = d.dest + chunk_len;
-          res = uzlib_uncompress_chksum(&d);
-          dlen -= chunk_len;
-          log_i("res: %d, dlen: %d", res, dlen);
-          if (res != TINF_OK)
-          {
-            break;
-          }
-        }
-
-        if (res != TINF_DONE)
-        {
-          log_e("Error during decompression: %d", res);
-          exit(-res);
-        }
-
-        log_i("decompressed %lu bytes", d.dest - dest);
-        log_i("RESULT\n%s", dest);
-        response.payload = String((char*)dest).substring(0, outlen);
-        free(source);
-        free(dest);
-        log_i("decompressed text: %s\ndecompressed text end", response.payload.c_str());
+        response.payload = decompressGZIPStream(http.getStreamPtr());
       } else {
         log_i("not GZIP");
-        String payload = http.getString();
-        log_d("%s", payload.c_str());
-        response.payload = payload;
+        response.payload = http.getString();
       }
     }
     else if (isCode3XX(httpCode))

--- a/src/HttpCommunicator.cpp
+++ b/src/HttpCommunicator.cpp
@@ -34,15 +34,15 @@ response getRequest(const String &url)
     log_i("[HTTP] GET... code: %d", httpCode);
     if (httpCode == HTTP_CODE_OK)
     {
-      String payload = http.getString();
-      log_d("%s", payload.c_str());
-      response.payload = payload;
-      log_i("%s", http.header("Content-Encoding").c_str());
+      log_d("Content-Encoding: %s", http.header("Content-Encoding").c_str());
       if (!http.header("Content-Encoding").compareTo("gzip"))
       {
         log_i("GZIP");
       } else {
         log_i("not GZIP");
+        String payload = http.getString();
+        log_d("%s", payload.c_str());
+        response.payload = payload;
       }
     }
     else if (isCode3XX(httpCode))

--- a/src/HttpCommunicator.cpp
+++ b/src/HttpCommunicator.cpp
@@ -38,6 +38,80 @@ response getRequest(const String &url)
       if (!http.header("Content-Encoding").compareTo("gzip"))
       {
         log_i("GZIP");
+
+        unsigned int dlen;
+        unsigned char *source, *dest;
+        int res;
+
+        uzlib_init();
+
+        WiFiClient *stream = http.getStreamPtr();
+        const unsigned int len = stream->available();
+        log_i("len: %d", len);
+        source = (unsigned char *)malloc(len);
+        const unsigned int c = stream->readBytes(source, len);
+        if (c != len)
+        {
+          log_e("Error reading bytes. stream length: %d, actualy read: %d", len, c);
+          exit(1);
+        }
+
+        log_i("source[len - 4]: %d, source[len - 3]: %d, source[len - 2]: %d,  source[len - 1]: %d",
+               source[len - 4], source[len - 3], source[len - 2], source[len - 1]);
+        // 解凍後の長さを計算
+        dlen = source[len - 1];
+        dlen = 256 * dlen + source[len - 2];
+        dlen = 256 * dlen + source[len - 3];
+        dlen = 256 * dlen + source[len - 4];
+
+        const unsigned int outlen = dlen;
+        log_i("outlen: %d", outlen);
+
+        // 計算したdlenと実際の長さが異なる場合があるので、余分に長さを確保する
+        dlen++;
+        dest = (unsigned char *)malloc(dlen);
+
+        struct uzlib_uncomp d;
+        uzlib_uncompress_init(&d, NULL, 0);
+
+        d.source = source;
+        d.source_limit = source + len - 4;
+        d.source_read_cb = NULL;
+
+        res = uzlib_gzip_parse_header(&d);
+        if (res != TINF_OK)
+        {
+          log_e("Error parsing header: %d", res);
+          exit(1);
+        }
+
+        d.dest_start = d.dest = dest;
+
+        while (dlen)
+        {
+          unsigned int chunk_len = dlen < OUT_CHUNK_SIZE ? dlen : OUT_CHUNK_SIZE;
+          d.dest_limit = d.dest + chunk_len;
+          res = uzlib_uncompress_chksum(&d);
+          dlen -= chunk_len;
+          log_i("res: %d, dlen: %d", res, dlen);
+          if (res != TINF_OK)
+          {
+            break;
+          }
+        }
+
+        if (res != TINF_DONE)
+        {
+          log_e("Error during decompression: %d", res);
+          exit(-res);
+        }
+
+        log_i("decompressed %lu bytes", d.dest - dest);
+        log_i("RESULT\n%s", dest);
+        response.payload = String((char*)dest).substring(0, outlen);
+        free(source);
+        free(dest);
+        log_i("decompressed text: %s\ndecompressed text end", response.payload.c_str());
       } else {
         log_i("not GZIP");
         String payload = http.getString();

--- a/src/HttpCommunicator.cpp
+++ b/src/HttpCommunicator.cpp
@@ -22,6 +22,10 @@ response getRequest(const String &url)
   response response;
   log_i("URL: %s", url.c_str());
 
+  const size_t headerKeysCount = 1;
+  const char *headerKeys[headerKeysCount] = {"Content-Encoding"};
+  http.collectHeaders(headerKeys, headerKeysCount);
+
   http.begin(url.c_str());
   int httpCode = http.GET();
   response.code = httpCode;
@@ -33,6 +37,13 @@ response getRequest(const String &url)
       String payload = http.getString();
       log_d("%s", payload.c_str());
       response.payload = payload;
+      log_i("%s", http.header("Content-Encoding").c_str());
+      if (!http.header("Content-Encoding").compareTo("gzip"))
+      {
+        log_i("GZIP");
+      } else {
+        log_i("not GZIP");
+      }
     }
     else if (isCode3XX(httpCode))
     {

--- a/src/HttpCommunicator.h
+++ b/src/HttpCommunicator.h
@@ -20,5 +20,6 @@ typedef struct{
 
 String convertHTTPStoHTTP(const String &url);
 bool isCode3XX(const int &code);
+String decompressGZIPStream(WiFiClient *gzipStream);
 response getRequest(const String &url);
 enum ParseResponseStatus parseResponse(const response &res, uint8_t &duration, Stack<String> &m3u8Urls, IndexQueue<String> &aacUrls);

--- a/src/HttpCommunicator.h
+++ b/src/HttpCommunicator.h
@@ -1,9 +1,11 @@
 #include <Arduino.h>
 #include <HTTPClient.h>
+#include <uzlib.h>
 #include "Stack.h"
 #include "IndexQueue.h"
 
 #define KILO 1000
+#define OUT_CHUNK_SIZE 1
 
 enum ParseResponseStatus {
   AAC_OR_TS,


### PR DESCRIPTION
http live streamingでは、プレイリストをgzip形式で渡してくることがある。([参考URL](https://dev.classmethod.jp/articles/cloudfront-hls-compress-objects-automatically/))
[uzlib](https://github.com/pfalcon/uzlib)を用いて解凍してから読み込む。
レスポンスヘッダに`Accept-Encoding: gzip`があるかどうかでgzip形式かを判定する。