### PR TITLE
READMEの、ESP8266Audio/src/AudioFileSourceHTTPStream.cppに関する記述を削除。

### DIFF
--- a/README-jp.md
+++ b/README-jp.md
@@ -18,17 +18,6 @@ M5StackおよびM5StickCでM3U8形式のWebラジオを再生するプログラ�
 ### 全M5コントローラ共通  
 [ESP8266Audio](https://github.com/earlephilhower/ESP8266Audio)  
 [uzlib](https://github.com/pfalcon/uzlib)  
-また、下記の通りコードを追加する必要あり。  
-
-#### ESP8266Audio/src/AudioFileSourceHTTPStream.cpp  
-```C++
-bool AudioFileSourceHTTPStream::close()
-{
-  http.end();
-  client.stop();  // このコードを追加する
-  return true;
-}
-```
 
 ## 使い方  
 ### PlatformIO  

--- a/README.md
+++ b/README.md
@@ -18,17 +18,6 @@ Support for .aac and .ts
 ### All M5 Controllers Common  
 [ESP8266Audio](https://github.com/earlephilhower/ESP8266Audio)  
 [uzlib](https://github.com/pfalcon/uzlib)  
-In addition, you need to add a code like the following.  
-
-#### ESP8266Audio/src/AudioFileSourceHTTPStream.cpp  
-```C++
-bool AudioFileSourceHTTPStream::close()
-{
-  http.end();
-  client.stop();  // Add this line
-  return true;
-}
-```
 
 ## Usage  
 ### PlatformIO  

--- a/src/AudioFileSourceHLSBuffer.cpp
+++ b/src/AudioFileSourceHLSBuffer.cpp
@@ -69,7 +69,6 @@ AudioFileSourceHLSBuffer::~AudioFileSourceHLSBuffer()
   buffer = NULL;
   while(sourceQueue->length()){
     AudioFileSource *src = sourceQueue->pop();
-    src->close();
     delete src;
   }
   delete sourceQueue;
@@ -154,7 +153,6 @@ bool AudioFileSourceHLSBuffer::changeSource()
   } else{
     AudioFileSource *oldSrc = src;
     src = sourceQueue->pop();
-    oldSrc->close();
     delete oldSrc;
   }
   log_e("Source Changed. size:%d queue length:%d", src->getSize(), sourceQueue->length());


### PR DESCRIPTION
今まで、[ESP8266Audio/src/AudioFileSourceHTTPStream.cpp::close()](https://github.com/earlephilhower/ESP8266Audio/blob/4ba7df1928dafc7cac72290931b213bcabe7d2d9/src/AudioFileSourceHTTPStream.cpp#L137-L141)でclient.close()を呼び出さないことがメモリリークの原因だと考えていた。しかしこれは間違いであった。
実際にはAudioFileSourceHTTPStreamのインスタンスに対するdelete処理を行っていなかったことがメモリリークの原因であり、その対策は[f2760ab](https://github.com/Yokohama-Miyazawa/M5HLSPlayer/commit/f2760ab3c7dead5749edd18df090656d95e76c23)や[9380ad2](https://github.com/Yokohama-Miyazawa/M5HLSPlayer/commit/9380ad2e2a615849b0e3912bf9741dfec3e0b898)で実施済み。
したがってESP8266Audio/src/AudioFileSourceHTTPStream.cppの修正は不要なので、READMEから削除。