### PR TITLE
状態用変数をstateに統一。

### DIFF
--- a/README-jp.md
+++ b/README-jp.md
@@ -209,6 +209,7 @@ Serial.println(volume);
 | STANDBY | セットアップ完了 |
 | PLAYING | 再生中 |
 | CHANNEL_CHANGING | HLSプレイリストのURLを変更中 |
+| RECOVERY_SEGMENT | セグメントファイルのURLキューを巻き戻し中 |
 | OTHERS| それ以外 |
 
 #### 使用例:
@@ -232,6 +233,9 @@ switch(state){
     break;
   case M3U8Player_State::CHANNEL_CHANGING:
     Serial.println("ch changing");
+    break;
+  case M3U8Player_State::RECOVERY_SEGMENT:
+    Serial.println("recovery segment");
     break;
   default:
     Serial.println("something error");

--- a/README.md
+++ b/README.md
@@ -207,7 +207,8 @@ Values and desrciptions are below
 | SETUP | setup in progress |
 | STANDBY | setup completed and able to start |
 | PLAYING | currently playing back |
-| CHANNEL_CHANGING | changing the url of HLS playlist |
+| CHANNEL_CHANGING | changing the URL of HLS playlist |
+| RECOVERY_SEGMENT | rewinding the queue of segment URLs |
 | OTHERS| the others |
 
 #### Example of use
@@ -231,6 +232,9 @@ switch(state){
     break;
   case M3U8Player_State::CHANNEL_CHANGING:
     Serial.println("ch changing");
+    break;
+  case M3U8Player_State::RECOVERY_SEGMENT:
+    Serial.println("recovery segment");
     break;
   default:
     Serial.println("something error");

--- a/src/M3U8Player.cpp
+++ b/src/M3U8Player.cpp
@@ -190,7 +190,10 @@ void M3U8Player::playAAC(void *m3u8PlayerInstance)
       {
         Serial.println("Playback stopped.");
         instance->ts->stop();
-        if (instance->state != M3U8Player_State::CHANNEL_CHANGING) instance->state = M3U8Player_State::RECOVERY_SEGMENT;
+        if (instance->state != M3U8Player_State::CHANNEL_CHANGING) {
+          instance->ts->reset();
+          instance->state = M3U8Player_State::RECOVERY_SEGMENT;
+        }
         while(instance->state != M3U8Player_State::STANDBY){
           delay(100);
         }

--- a/src/M3U8Player.cpp
+++ b/src/M3U8Player.cpp
@@ -174,7 +174,6 @@ void M3U8Player::playAAC(void *m3u8PlayerInstance)
         instance->buff->close();
         delete instance->buff;
       }
-      if(instance->urls) delete instance->urls;
       goto restart;
     } else {
       instance->state = M3U8Player_State::PLAYING;

--- a/src/M3U8Player.cpp
+++ b/src/M3U8Player.cpp
@@ -27,7 +27,6 @@ M3U8Player::M3U8Player(String url, const float &startVolume, const bool &isAutoS
   volume = startVolume;
   buffSize = bufferSize;
   isReferringUrls = false;
-  isChannelChanging = false;
   stationUrl = url;
   buff = NULL;
   nextBuff = NULL;
@@ -116,7 +115,6 @@ void M3U8Player::changeChannel()
   ts->switchMode(buff->isTS());
   nextBuff = NULL;
   nextUrls = NULL;
-  isChannelChanging = false;
   state = M3U8Player_State::PLAYING;
   log_e("Changing channel completed.");
 }
@@ -128,7 +126,8 @@ void M3U8Player::scrapeAAC(void* m3u8PlayerInstance)
 
   while (true)
   {
-    if (instance->isChannelChanging) {
+    if (instance->state == M3U8Player_State::CHANNEL_CHANGING)
+    {
       log_e("Now channel changing...");
       lastRequested = 0;
       delay(100);
@@ -193,7 +192,7 @@ void M3U8Player::playAAC(void *m3u8PlayerInstance)
         instance->state = M3U8Player_State::PLAYING;
         continue;
       }
-      if (instance->isChannelChanging && instance->nextBuff && instance->nextBuff->isSetup())
+      if (instance->state == M3U8Player_State::CHANNEL_CHANGING && instance->nextBuff && instance->nextBuff->isSetup())
       {
         instance->changeChannel();
         break;
@@ -246,7 +245,6 @@ bool M3U8Player::changeStationURL(const String &url)
   }
   while(isReferringUrls) delay(100);
   state = M3U8Player_State::CHANNEL_CHANGING;
-  isChannelChanging = true;
   stationUrl = url;
   nextUrls = new HLSUrl(stationUrl);
   setBuffer(nextUrls);

--- a/src/M3U8Player.h
+++ b/src/M3U8Player.h
@@ -64,7 +64,6 @@ private:
   HLSUrl* nextUrls;
   bool isReferringUrls;
   bool isChannelChanging;
-  bool isPlaying;
   void setBuffer(HLSUrl* url);
   bool recovery();
   void changeChannel();

--- a/src/M3U8Player.h
+++ b/src/M3U8Player.h
@@ -31,6 +31,7 @@ enum class M3U8Player_State
   STANDBY,
   PLAYING,
   CHANNEL_CHANGING,
+  RECOVERY_SEGMENT,
   OTHERS
 };
 
@@ -62,7 +63,6 @@ private:
   uint8_t targetDuration;
   HLSUrl* urls;
   HLSUrl* nextUrls;
-  bool isReferringUrls;
   void setBuffer(HLSUrl* url);
   bool recovery();
   void changeChannel();

--- a/src/M3U8Player.h
+++ b/src/M3U8Player.h
@@ -63,7 +63,6 @@ private:
   HLSUrl* urls;
   HLSUrl* nextUrls;
   bool isReferringUrls;
-  bool isChannelChanging;
   void setBuffer(HLSUrl* url);
   bool recovery();
   void changeChannel();


### PR DESCRIPTION
今までM3U8Playerの状態を表す変数は`state`の他に`isPlaying`, `isRefferingUrls`, `isChannelChanging`が存在した。
これらを廃止。