### PR TITLE
getRequest()がhttpsに対応。

### DIFF
--- a/src/HttpCommunicator.cpp
+++ b/src/HttpCommunicator.cpp
@@ -93,7 +93,7 @@ String decompressGZIPStream(WiFiClient *gzipStream){
   return unzipped;
 }
 
-response getRequest(const String &url)
+response getRequest(const String &url, const char* rootca)
 {
   HTTPClient http;
   response response;
@@ -103,7 +103,13 @@ response getRequest(const String &url)
   const char *headerKeys[headerKeysCount] = {"Content-Encoding"};
   http.collectHeaders(headerKeys, headerKeysCount);
 
-  http.begin(url.c_str());
+  if(rootca == NULL || url.indexOf("https") != 0){
+    log_i("HTTP");
+    http.begin(convertHTTPStoHTTP(url).c_str());
+  }else{
+    log_i("HTTPS");
+    http.begin(url.c_str(), rootca);
+  }
   int httpCode = http.GET();
   response.code = httpCode;
   if (httpCode > 0)
@@ -212,11 +218,11 @@ enum ParseResponseStatus parseResponse(const response &res, uint8_t &duration, S
       if (isCode3XX(httpCode))
       {
         m3u8Urls.pop();
-        m3u8Urls.push(convertHTTPStoHTTP(newUrl));
+        m3u8Urls.push(newUrl);
       }
       else if (!m3u8Urls.search(newUrl))
       {
-        m3u8Urls.push(convertHTTPStoHTTP(newUrl));
+        m3u8Urls.push(newUrl);
       }
     }
   }

--- a/src/HttpCommunicator.h
+++ b/src/HttpCommunicator.h
@@ -21,5 +21,5 @@ typedef struct{
 String convertHTTPStoHTTP(const String &url);
 bool isCode3XX(const int &code);
 String decompressGZIPStream(WiFiClient *gzipStream);
-response getRequest(const String &url);
+response getRequest(const String &url, const char *rootca = NULL);
 enum ParseResponseStatus parseResponse(const response &res, uint8_t &duration, Stack<String> &m3u8Urls, IndexQueue<String> &aacUrls);


### PR DESCRIPTION
HLSプレイリスト(.m3u8)を取得する関数getRequest()がhttpsに対応。 httpsを利用する際は第二引数にルート証明書をBASE64形式で与える。